### PR TITLE
fix - ensure at least 1 worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ GHMLFS_SOURCE_TOKEN=ghp_xxx              # Source token
 GHMLFS_TARGET_ORGANIZATION=mona-emu      # Target organization name
 GHMLFS_TARGET_HOSTNAME=                  # Target hostname
 GHMLFS_TARGET_TOKEN=ghp_yyy              # Target token
-GHMLFS_WORKERS=                          # worker count
+GHMLFS_WORKERS=1                         # worker count
 GHMLFS_WORKDIR=                          # work directory
 GHMLFS_FILE=${GHMLFS_SOURCE_ORGANIZATION}_lfs.csv # Input CSV file name
 ```

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -21,7 +21,7 @@ var pullCmd = &cobra.Command{
 			"GHMLFS_WORKERS":         false,
 		})
 
-		ShowConnectionStatus("export")
+		ShowConnectionStatus("pull")
 		if err := pull.PullLFSFromCSV(); err != nil {
 			fmt.Printf("failed to export variables: %v\n", err)
 		}

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -25,6 +25,11 @@ func PullLFSFromCSV() error {
 	workDir := viper.GetString("GHMLFS_WORK_DIR")
 	maxWorkers := viper.GetInt("GHMLFS_WORKERS")
 
+	// Ensure at least 1 worker
+	if maxWorkers <= 0 {
+		maxWorkers = 1
+	}
+
 	// Read CSV file
 	file, err := os.Open(inputFile)
 	if err != nil {


### PR DESCRIPTION
This addresses a specific case where not specifying the environment variable `GHMLFS_WORKERS=` in the .env file can cause the script to fail due to lack of workers. Since zero is technically a number it passes CLI requirements and results in failure on pull commands.

This small fixes ensures a small error in the .env will still give the right outcome, docs have also been updated to reflect workers as being set to `1`.