### PR TITLE
general clean up

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 mona-actions
+Copyright (c) 2024-2025 mona-actions
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 gh extension install mona-actions/gh-migrate-lfs
 ```
 
+## Upgrade
+
+```sh
+gh extension upgrade gh-migrate-lfs
+```
+
 ## Usage: Export
 
 Export a list of repositories containing Git LFS files to a CSV file.
@@ -163,17 +169,18 @@ Global Flags:
       --no-proxy string      No proxy list (can also use NO_PROXY env var)
 ```
 
+Example usage with proxy:
+
 ```bash
-# Example usage with proxy:
 gh migrate-lfs pull \
   --file mona-actions_lfs.csv \
   --work-dir ./lfs_repos \
   --source-token ghp_xxxxxxxxxxxx \
   --https-proxy https://proxy.example.com:8080
 ```
+Example with environment variables:
 
 ```bash
-# Example with environment variables:
 export HTTPS_PROXY=https://proxy.example.com:8080
 export NO_PROXY=github.internal.com
 export GHMLFS_TARGET_TOKEN=ghp_...
@@ -193,7 +200,6 @@ The tool supports loading configuration from a `.env` file. This provides an alt
 1. Create a `.env` file in your working directory:
 
 ```bash
-# GitHub Migration LFS (GHMLFS)
 GHMLFS_SOURCE_ORGANIZATION=mona-actions  # Source organization name
 GHMLFS_SOURCE_HOSTNAME=                  # Source hostname
 GHMLFS_SOURCE_TOKEN=ghp_xxx              # Source token
@@ -254,7 +260,7 @@ This configuration allows you to:
 
 - Requires `git-lfs` to be installed
 - Target repositories must exist in the destination organization before syncing
-- Large LFS files may take significant time to download and upload
+- Large LFS repositories will take significant time to download and upload
 - Network bandwidth and storage space should be considered when migrating large LFS repositories
 - The tool will retry failed operations but may still encounter persistent access or network issues
 - Deep directory structures may require adjusting the search depth parameter

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -23,7 +23,7 @@ var pullCmd = &cobra.Command{
 
 		ShowConnectionStatus("pull")
 		if err := pull.PullLFSFromCSV(); err != nil {
-			fmt.Printf("failed to export variables: %v\n", err)
+			fmt.Printf("failed to export lfs repositories: %v\n", err)
 		}
 	},
 }

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -100,21 +100,12 @@ func SyncLFSContent(repoName, workDir, targetOrg, token string) error {
 
 	// Set environment variables
 	env := append(os.Environ(),
-		"GIT_LFS_SKIP_SMUDGE=1",
 		"GIT_TERMINAL_PROMPT=0",
 		"GIT_TRACE=1",
 		"GIT_CURL_VERBOSE=1",
 	)
 
 	fmt.Printf("Syncing %s to %s/%s...\n", repoName, targetOrg, repoName)
-
-	// Initialize Git LFS
-	lfsInstallCmd := exec.Command("git", "lfs", "install")
-	lfsInstallCmd.Dir = repoPath
-	lfsInstallCmd.Env = env
-	if err := lfsInstallCmd.Run(); err != nil {
-		return fmt.Errorf("failed to install git lfs: %w", err)
-	}
 
 	// Set the remote URL without embedding the token
 	baseURL := fmt.Sprintf("https://github.com/%s/%s.git", targetOrg, repoName)
@@ -134,21 +125,10 @@ func SyncLFSContent(repoName, workDir, targetOrg, token string) error {
 		return fmt.Errorf("failed to get remote url: %w", err)
 	}
 	remoteURL := strings.TrimSpace(string(output))
-	fmt.Printf("Verified remote URL: %s\n", remoteURL)
-
-	// Push all branches
-	fmt.Printf("Pushing content for %s...\n", repoName)
-	pushCmd := exec.Command("git", "push", "--all", "origin")
-	pushCmd.Dir = repoPath
-	pushCmd.Env = env
-	if output, err := pushCmd.CombinedOutput(); err != nil {
-		// Mask token in error message
-		errMsg := strings.ReplaceAll(string(output), token, "****")
-		return fmt.Errorf("failed to push content: %s, %w", errMsg, err)
-	}
+	fmt.Printf("remote URL: %s\n", remoteURL)
 
 	// Push LFS content
-	lfsPushCmd := exec.Command("git", "lfs", "push", "--all", "origin")
+	lfsPushCmd := exec.Command("git", "lfs", "push", "--all")
 	lfsPushCmd.Dir = repoPath
 	lfsPushCmd.Env = env
 	if output, err := lfsPushCmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
This contains several updates and improvements.

- accurate error message on export failure
- update pull commands to use mirror, users seem to prefer it
- remove LFS check from pull, it's now part of main.go
- update license years
- readme updates, in particular updating the extension and limitations of lfs